### PR TITLE
(feat/whitepaper): Add Lcly whitepaper and roadmap pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,8 @@ import {
   Heart,
   SquareUserRound,
   HelpCircle,
+  Rocket,
+  FileText,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import Image from "next/image";
@@ -62,7 +64,7 @@ export default function Home() {
             />
             <LclyLogo className="h-5 sm:h-7 w-auto text-black/90 dark:text-white -mb-1.5" />
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3 md:gap-2">
             <Link href="/about">
               <Button variant="secondary" size="icon">
                 <HelpCircle className="h-4 w-4" />
@@ -80,7 +82,7 @@ export default function Home() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.2 }}
-          className="max-w-2xl flex flex-col lg:flex-row lg:max-w-none lg:items-center lg:justify-between lg:gap-8 mt-16 lg:mt-0 h-[75dvh] lg:h-[100dvh]"
+          className="max-w-2xl flex flex-col lg:flex-row lg:max-w-none lg:items-center lg:justify-between lg:gap-8 mt-16 lg:mt-0 h-[100dvh]"
         >
           <div className="flex-1 flex flex-col justify-center">
             <h2 className="flex items-center gap-2 text-xs leading-7 bg-primary/5 font-semibold text-primary px-3 rounded-full self-start border border-primary/10 text-foreground/60">
@@ -94,7 +96,7 @@ export default function Home() {
               Your Local Community Hub
             </p>
             <p className="mt-2 text-lg leading-8 text-muted-foreground">
-              Lcly is an Free &amp; Open Source project, building digital
+              Lcly is an Free &amp; Open Source project building digital
               infrastructure for local communities. Find your local community or
               if you&apos;re a developer come build Lcly with us (
               <a
@@ -107,9 +109,9 @@ export default function Home() {
               </a>
               ).
             </p>
-            <div className="mt-6">
+            <div className="mt-10">
               <PostcodeSearch />
-              <div className="mt-6 flex items-center gap-2">
+              <div className="mt-8 flex items-center gap-2">
                 <div className="flex -space-x-2">
                   {[
                     "/avatars/amy.png",
@@ -134,6 +136,28 @@ export default function Home() {
                 <p className="text-sm text-muted-foreground">
                   Join 1000s building their local community
                 </p>
+              </div>
+
+              {/* New Documentation Links */}
+              <div className="mt-6 flex flex-row gap-3 text-foreground/70">
+                <Link href="/roadmap">
+                  <Button
+                    variant="outline"
+                    className="w-full sm:w-auto group hover:border-primary/20 hover:bg-primary/5"
+                  >
+                    <Rocket className="mr-2 h-4 w-4 group-hover:animate-pulse" />
+                    Our Roadmap
+                  </Button>
+                </Link>
+                <Link href="/whitepaper">
+                  <Button
+                    variant="outline"
+                    className="w-full sm:w-auto group hover:border-primary/20 hover:bg-primary/5"
+                  >
+                    <FileText className="mr-2 h-4 w-4 group-hover:animate-pulse" />
+                    Read the Whitepaper
+                  </Button>
+                </Link>
               </div>
             </div>
           </div>
@@ -349,7 +373,7 @@ export default function Home() {
         className="mt-32 sm:mt-40"
       >
         <div className="mx-auto max-w-7xl px-6 pb-8 lg:px-8">
-          <div className="border-t border-border pt-8">
+          <div className="border-t border-border pt-8 flex flex-row items-center justify-between">
             <p className="text-sm leading-5 text-muted-foreground">
               &copy; {new Date().getFullYear()} Lcly. Build Lcly with us (
               <a

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -1,0 +1,405 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import {
+  Rocket,
+  Map,
+  Users,
+  Smartphone,
+  Building2,
+  Shield,
+  Leaf,
+  Heart,
+  Target,
+  CheckCircle2,
+  MapPin,
+  Newspaper,
+  AppWindow,
+  Database,
+  Vote,
+} from "lucide-react";
+
+export default function RoadmapPage() {
+  return (
+    <div className="container mx-auto py-8 sm:py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="relative mb-8">
+          <Link href="/">
+            <Button variant="secondary" size="icon" className="">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+        </div>
+
+        <h1 className="text-3xl sm:text-4xl font-bold mb-4 sm:mb-8">
+          Development Roadmap
+        </h1>
+        <p className="text-muted-foreground mb-8 sm:mb-12 text-sm sm:text-base">
+          Our development roadmap outlines the planned features and improvements
+          for Lcly. This is a living document that will be updated based on
+          community feedback and priorities.
+        </p>
+
+        <div className="space-y-6 sm:space-y-12">
+          {/* Phase 1 */}
+          <Card className="border-l-4 border-l-sky-300">
+            <CardHeader className="pb-4 sm:pb-6">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Rocket className="h-6 w-6 sm:h-8 sm:w-8 text-sky-500 shrink-0" />
+                  <CardTitle className="text-xl sm:text-2xl">
+                    Phase 1: Strengthen the Core Platform
+                  </CardTitle>
+                </div>
+                <Badge className="bg-sky-50 text-sky-500 hover:bg-sky-100 w-fit">
+                  0-2 months
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4 sm:space-y-6">
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Goals
+                  </h3>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base">
+                    <li>Finalize the foundational user experience</li>
+                    <li>
+                      Ensure essential data structures and APIs are in place
+                    </li>
+                    <li>Decide on a brand identity and design system</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Key Tasks
+                  </h3>
+                  <div className="space-y-3 sm:space-y-4">
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Refine MVP Features
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>
+                          Review existing auth, profiles, and posts features
+                        </li>
+                        <li>
+                          Enhance or fix critical bugs in core functionality
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Set Up Basic Local Data Feeds
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Integrate open-data source for local boundaries</li>
+                        <li>Establish minimal reference data set</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Establish Data Ingestion Strategy
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Structure and store data in Supabase</li>
+                        <li>Ensure compliance with open-data licensing</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Phase 2 */}
+          <Card className="border-l-4 border-l-emerald-300">
+            <CardHeader className="pb-4 sm:pb-6">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Map className="h-6 w-6 sm:h-8 sm:w-8 text-emerald-500 shrink-0" />
+                  <CardTitle className="text-xl sm:text-2xl">
+                    Phase 2: Expand Local Information & Mapping
+                  </CardTitle>
+                </div>
+                <Badge className="bg-emerald-50 text-emerald-500 hover:bg-emerald-100 w-fit">
+                  2-4 months
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4 sm:space-y-6">
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Goals
+                  </h3>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base">
+                    <li>
+                      Introduce interactive local map and boundary overlays
+                    </li>
+                    <li>
+                      Populate local services data in targeted pilot areas
+                    </li>
+                    <li>Create foundation for local newsfeed</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Key Tasks
+                  </h3>
+                  <div className="space-y-3 sm:space-y-4">
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Local Map & Boundary Integration
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Implement map component in Next.js</li>
+                        <li>Overlay boundary lines from open data sets</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Local Services Layer
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Add official local service points to the map</li>
+                        <li>Implement caching for performance</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Phase 3 */}
+          <Card className="border-l-4 border-l-violet-300">
+            <CardHeader className="pb-4 sm:pb-6">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Users className="h-6 w-6 sm:h-8 sm:w-8 text-violet-500 shrink-0" />
+                  <CardTitle className="text-xl sm:text-2xl">
+                    Phase 3: Community Features & Scaling
+                  </CardTitle>
+                </div>
+                <Badge className="bg-violet-50 text-violet-500 hover:bg-violet-100 w-fit">
+                  4-7 months
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4 sm:space-y-6">
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Goals
+                  </h3>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base">
+                    <li>Launch initial pilot in selected areas</li>
+                    <li>Add advanced local community features</li>
+                    <li>Strengthen user interaction flows</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Key Tasks
+                  </h3>
+                  <div className="space-y-3 sm:space-y-4">
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Local Communities & Groups
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>City/town group functionality</li>
+                        <li>Bin collection schedules and local events</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Guides & Noticeboard
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Wiki-like system for local tips</li>
+                        <li>Digital noticeboard for community postings</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Phase 4 */}
+          <Card className="border-l-4 border-l-amber-300">
+            <CardHeader className="pb-4 sm:pb-6">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Smartphone className="h-6 w-6 sm:h-8 sm:w-8 text-amber-500 shrink-0" />
+                  <CardTitle className="text-xl sm:text-2xl">
+                    Phase 4: Mobile App & Broader Coverage
+                  </CardTitle>
+                </div>
+                <Badge className="bg-amber-50 text-amber-500 hover:bg-amber-100 w-fit">
+                  7-10 months
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4 sm:space-y-6">
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Goals
+                  </h3>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base">
+                    <li>Develop dedicated mobile app for iOS/Android</li>
+                    <li>Broaden coverage to additional UK regions</li>
+                    <li>Refine local data ingestion processes</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Key Tasks
+                  </h3>
+                  <div className="space-y-3 sm:space-y-4">
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Mobile App Development
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>React Native or Expo implementation</li>
+                        <li>Push notifications for community updates</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Automated Data Sync
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Scale up data ingestion pipeline</li>
+                        <li>Schedule periodic data refreshes</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Phase 5 */}
+          <Card className="border-l-4 border-l-rose-300">
+            <CardHeader className="pb-4 sm:pb-6">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Building2 className="h-6 w-6 sm:h-8 sm:w-8 text-rose-500 shrink-0" />
+                  <CardTitle className="text-xl sm:text-2xl">
+                    Phase 5: Advanced Engagement & Partnerships
+                  </CardTitle>
+                </div>
+                <Badge className="bg-rose-50 text-rose-500 hover:bg-rose-100 w-fit">
+                  10-12+ months
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4 sm:space-y-6">
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Goals
+                  </h3>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base">
+                    <li>Integrate local democracy features</li>
+                    <li>Partner with local authorities and institutions</li>
+                    <li>Standardize updates across UK communities</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold text-base sm:text-lg mb-2">
+                    Key Tasks
+                  </h3>
+                  <div className="space-y-3 sm:space-y-4">
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Local Democracy Tools
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Community polling and petition features</li>
+                        <li>Government portal integrations</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4 className="font-medium text-sm sm:text-base mb-1">
+                        Full UK Rollout
+                      </h4>
+                      <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                        <li>Coverage of all counties and wards</li>
+                        <li>Local volunteer data curation</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Ongoing Considerations */}
+          <Card className="border-l-4 border-l-slate-300">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <Target className="h-6 w-6 sm:h-8 sm:w-8 text-slate-500 shrink-0" />
+                <CardTitle className="text-xl sm:text-2xl">
+                  Ongoing Considerations
+                </CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Shield className="h-5 w-5 text-slate-500 shrink-0" />
+                    <h3 className="font-semibold text-base sm:text-lg">
+                      Security & Privacy
+                    </h3>
+                  </div>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                    <li>GDPR compliance</li>
+                    <li>Data source verification</li>
+                  </ul>
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Leaf className="h-5 w-5 text-slate-500 shrink-0" />
+                    <h3 className="font-semibold text-base sm:text-lg">
+                      Sustainability
+                    </h3>
+                  </div>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                    <li>Revenue model exploration</li>
+                    <li>Open-source development</li>
+                  </ul>
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <Heart className="h-5 w-5 text-slate-500 shrink-0" />
+                    <h3 className="font-semibold text-base sm:text-lg">
+                      Community
+                    </h3>
+                  </div>
+                  <ul className="list-disc pl-4 sm:pl-6 space-y-1 text-sm sm:text-base text-muted-foreground">
+                    <li>Content moderation</li>
+                    <li>Local moderator roles</li>
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/whitepaper/page.tsx
+++ b/app/whitepaper/page.tsx
@@ -1,0 +1,87 @@
+import fs from "fs";
+import path from "path";
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import "@/components/thoughts/editor.css";
+
+import { TableOfContents } from "@/components/toc";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import LclyLogo from "@/components/logos/LclyLogo";
+import { WhitepaperContent } from "@/components/whitepaper/content";
+
+export const metadata: Metadata = {
+  title: "Lcly Whitepaper",
+  description: "Building Public Digital Infrastructure for UK Communities",
+};
+
+async function getWhitepaper() {
+  const filePath = path.join(process.cwd(), "content", "whitepaper.md");
+  try {
+    const source = fs.readFileSync(filePath, "utf8");
+    return source;
+  } catch (error) {
+    console.error("Error reading whitepaper:", error);
+    return null;
+  }
+}
+
+async function getEli5Whitepaper() {
+  const filePath = path.join(process.cwd(), "content", "whitepaper-eli5.md");
+  try {
+    const source = fs.readFileSync(filePath, "utf8");
+    return source;
+  } catch (error) {
+    console.error("Error reading ELI5 whitepaper:", error);
+    return null;
+  }
+}
+
+export default async function WhitepaperPage() {
+  const source = await getWhitepaper();
+  const eli5Source = await getEli5Whitepaper();
+
+  if (!source || !eli5Source) {
+    notFound();
+  }
+
+  return (
+    <div className="h-screen overflow-y-scroll scroll-pt-24">
+      <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container flex h-14 items-center px-6">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="mr-4 hidden md:flex"
+            asChild
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <LclyLogo className="h-4 w-auto" />
+        </div>
+      </header>
+
+      <div className="container relative mx-auto flex max-w-7xl gap-10 px-6 py-8">
+        <aside className="sticky top-20 hidden h-[calc(100vh-80px)] w-64 shrink-0 lg:block">
+          <ScrollArea className="h-full py-6 pr-6">
+            <div className="mb-4">
+              <h4 className="mb-1 text-sm font-medium">On this page</h4>
+              <TableOfContents source={source} />
+            </div>
+          </ScrollArea>
+        </aside>
+        <Separator orientation="vertical" className="hidden lg:block" />
+        <main className="w-full min-w-0">
+          <div className="mx-auto max-w-3xl space-y-8">
+            <WhitepaperContent source={source} eli5Source={eli5Source} />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/login-button.tsx
+++ b/components/auth/login-button.tsx
@@ -9,9 +9,9 @@ export function LoginButton() {
   if (user) {
     return (
       <Link href="/profile">
-        <button className="flex items-center gap-2 rounded-full bg-gray-800 px-3 py-1 h-10 text-sm text-white hover:bg-gray-700">
-          <UserAvatar className="h-7 w-7" />
-          My Profile
+        <button className="flex items-center gap-2 rounded-full bg-black p-0 md:px-3 md:py-1 h-10 w-10 md:w-auto text-sm text-white hover:bg-gray-900">
+          <UserAvatar className="h-10 w-10 md:h-7 md:w-7" />
+          <span className="hidden md:block">My Profile</span>
         </button>
       </Link>
     );

--- a/components/map-button.tsx
+++ b/components/map-button.tsx
@@ -12,9 +12,9 @@ export function MapButton() {
 
   return (
     <Link href="/map">
-      <Button variant="secondary" className="gap-2 h-10">
+      <Button variant="secondary" className="gap-2 h-10 w-10 md:w-auto">
         <Map className="h-4 w-4" />
-        {postcode || "Map"}
+        <span className="hidden md:block">{postcode || "Map"}</span>
       </Button>
     </Link>
   );

--- a/components/postcode-search.tsx
+++ b/components/postcode-search.tsx
@@ -56,7 +56,7 @@ export function PostcodeSearch({
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex w-full max-w-sm gap-2 items-center"
+      className="flex w-full max-w-md gap-2 items-center"
     >
       <Input
         type="text"

--- a/components/thoughts/editor.css
+++ b/components/thoughts/editor.css
@@ -85,6 +85,10 @@
   font-style: italic;
 }
 
+.markup-editor a {
+  color: #0ea5e9;
+}
+
 .markup-editor blockquote {
   border-left: 3px solid #e5e7eb;
   padding-left: 1em;

--- a/components/toc.tsx
+++ b/components/toc.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { useMounted } from "@/hooks/use-mounted";
+
+interface Item {
+  title: string;
+  url: string;
+  items?: Item[];
+  depth: number;
+}
+
+function getHeadings(source: string) {
+  // Get all lines that start with one or more #
+  const headingLines = source
+    .split("\n")
+    .filter((line) => /^#{1,6}\s/.test(line));
+
+  const headings: Item[] = [];
+  const stack: Item[] = [];
+
+  headingLines.forEach((line) => {
+    const match = line.match(/^(#{1,6})\s(.+)$/);
+    if (!match) return;
+
+    const depth = match[1].length;
+    const title = match[2];
+    const url = `#${title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "")}`;
+
+    const heading: Item = { title, url, depth };
+
+    // Find the parent heading
+    while (stack.length > 0 && stack[stack.length - 1].depth >= heading.depth) {
+      stack.pop();
+    }
+
+    if (stack.length > 0) {
+      const parent = stack[stack.length - 1];
+      if (!parent.items) parent.items = [];
+      parent.items.push(heading);
+    } else {
+      headings.push(heading);
+    }
+
+    stack.push(heading);
+  });
+
+  return headings;
+}
+
+interface TreeProps {
+  items: Item[];
+  activeItem?: string;
+  depth?: number;
+}
+
+function Tree({ items, activeItem, depth = 1 }: TreeProps) {
+  return items?.length ? (
+    <ul className={depth === 1 ? "space-y-2" : "mt-2 space-y-2"}>
+      {items.map((item, index) => {
+        return (
+          <li key={index}>
+            <a
+              href={item.url}
+              className={`inline-block no-underline transition-colors hover:text-foreground ${
+                activeItem === item.url
+                  ? "font-medium text-foreground"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {item.title}
+            </a>
+            {item.items?.length ? (
+              <Tree
+                items={item.items}
+                activeItem={activeItem}
+                depth={depth + 1}
+              />
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  ) : null;
+}
+
+interface TableOfContentsProps {
+  source: string;
+}
+
+export function TableOfContents({ source }: TableOfContentsProps) {
+  const [activeItem, setActiveItem] = useState<string>();
+  const mounted = useMounted();
+  const { theme } = useTheme();
+
+  const headings = getHeadings(source);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveItem(`#${entry.target.id}`);
+          }
+        });
+      },
+      { rootMargin: "0% 0% -80% 0%" }
+    );
+
+    const elements = document.querySelectorAll("h2, h3, h4");
+    elements.forEach((elem) => observer.observe(elem));
+
+    return () => observer.disconnect();
+  }, [mounted]);
+
+  return <Tree items={headings} activeItem={activeItem} />;
+}

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/components/whitepaper/content.tsx
+++ b/components/whitepaper/content.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { Button } from "@/components/ui/button";
+import { BookOpen, BookOpenText } from "lucide-react";
+
+interface WhitepaperContentProps {
+  source: string;
+  eli5Source: string;
+}
+
+export function WhitepaperContent({
+  source,
+  eli5Source,
+}: WhitepaperContentProps) {
+  const [isEli5Mode, setIsEli5Mode] = useState(false);
+
+  const markdownComponents = {
+    h1: ({ node, ...props }: any) => {
+      const id = props.children
+        ?.toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+      return <h1 id={id} {...props} />;
+    },
+    h2: ({ node, ...props }: any) => {
+      const id = props.children
+        ?.toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+      return <h2 id={id} {...props} />;
+    },
+    h3: ({ node, ...props }: any) => {
+      const id = props.children
+        ?.toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+      return <h3 id={id} {...props} />;
+    },
+    h4: ({ node, ...props }: any) => {
+      const id = props.children
+        ?.toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+      return <h4 id={id} {...props} />;
+    },
+    a: ({ node, ...props }: any) => (
+      <a target="_blank" rel="noopener noreferrer" {...props} />
+    ),
+  };
+
+  return (
+    <>
+      <div className="flex justify-end mb-8">
+        <Button
+          variant={isEli5Mode ? "default" : "outline"}
+          onClick={() => setIsEli5Mode(!isEli5Mode)}
+          className="flex items-center gap-2"
+        >
+          {isEli5Mode ? (
+            <BookOpenText className="h-4 w-4" />
+          ) : (
+            <BookOpen className="h-4 w-4" />
+          )}
+          {isEli5Mode ? "Read Full Version" : "ELI5 Version"}
+        </Button>
+      </div>
+      <article className="prose prose-slate max-w-none dark:prose-invert prose-headings:scroll-mt-[var(--scroll-mt)] prose-headings:font-heading prose-headings:font-bold prose-blockquote:border-l-2 prose-blockquote:border-slate-300 prose-blockquote:font-normal dark:prose-blockquote:border-slate-700 prose-blockquote:not-italic prose-li:my-0 prose-img:rounded-lg markup-editor">
+        <ReactMarkdown components={markdownComponents}>
+          {isEli5Mode ? eli5Source : source}
+        </ReactMarkdown>
+      </article>
+    </>
+  );
+}

--- a/components/whitepaper/content.tsx
+++ b/components/whitepaper/content.tsx
@@ -4,11 +4,22 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Button } from "@/components/ui/button";
 import { BookOpen, BookOpenText } from "lucide-react";
+import type { Components } from "react-markdown";
 
 interface WhitepaperContentProps {
   source: string;
   eli5Source: string;
 }
+
+type HeadingProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  HTMLHeadingElement
+>;
+
+type AnchorProps = React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>;
 
 export function WhitepaperContent({
   source,
@@ -16,8 +27,8 @@ export function WhitepaperContent({
 }: WhitepaperContentProps) {
   const [isEli5Mode, setIsEli5Mode] = useState(false);
 
-  const markdownComponents = {
-    h1: ({ node, ...props }: any) => {
+  const markdownComponents: Components = {
+    h1: (props: HeadingProps) => {
       const id = props.children
         ?.toString()
         .toLowerCase()
@@ -25,7 +36,7 @@ export function WhitepaperContent({
         .replace(/(^-|-$)/g, "");
       return <h1 id={id} {...props} />;
     },
-    h2: ({ node, ...props }: any) => {
+    h2: (props: HeadingProps) => {
       const id = props.children
         ?.toString()
         .toLowerCase()
@@ -33,7 +44,7 @@ export function WhitepaperContent({
         .replace(/(^-|-$)/g, "");
       return <h2 id={id} {...props} />;
     },
-    h3: ({ node, ...props }: any) => {
+    h3: (props: HeadingProps) => {
       const id = props.children
         ?.toString()
         .toLowerCase()
@@ -41,7 +52,7 @@ export function WhitepaperContent({
         .replace(/(^-|-$)/g, "");
       return <h3 id={id} {...props} />;
     },
-    h4: ({ node, ...props }: any) => {
+    h4: (props: HeadingProps) => {
       const id = props.children
         ?.toString()
         .toLowerCase()
@@ -49,7 +60,7 @@ export function WhitepaperContent({
         .replace(/(^-|-$)/g, "");
       return <h4 id={id} {...props} />;
     },
-    a: ({ node, ...props }: any) => (
+    a: (props: AnchorProps) => (
       <a target="_blank" rel="noopener noreferrer" {...props} />
     ),
   };

--- a/content/whitepaper-eli5.md
+++ b/content/whitepaper-eli5.md
@@ -1,0 +1,17 @@
+# ELI5 (Explain Like I'm 5) Version of the Lcly Whitepaper
+
+Think of Lcly as your digital village hall—an online spot where you can pop in for local news, see which bins go out when, and find out what's happening on the High Street. It's open to everyone (like a public building you can wander into), and the best bit is you know exactly how it's built and who's running it (because it's open source and totally transparent).
+
+## Easy to Use
+
+No faff—just hop on, set up a quick profile, and start chatting with your neighbours.
+
+## Trustworthy
+
+We're not here to nick your personal info or blast you with ads. Everything's about keeping things safe and reliable for real people.
+
+## Built for the Community
+
+Councils, local groups, or even your mate who codes on weekends can all chip in, add features, and make it better for everyone.
+
+So if you want a single place to check local events, share tips, or just see what's going on around the corner, Lcly's got you covered—like your friendly community noticeboard, but online.

--- a/content/whitepaper.md
+++ b/content/whitepaper.md
@@ -1,0 +1,169 @@
+# Lcly Whitepaper
+
+## Building Public Digital Infrastructure for UK Communities
+
+**Authors:** The Lcly Community - **Version:** Draft 1.0
+
+## 1. Abstract
+
+Lcly is an open-source digital platform designed to serve as public infrastructure for local communities across the United Kingdom. By placing user experience (UX) and trust at the forefront, Lcly empowers government entities, businesses, and independent developers to deploy local-oriented applications, integrations, and services with minimal friction. Our architectural approach prioritizes modularity, privacy, and a standardized means of engagement, ensuring real people can access critical local information and services with confidence.
+
+## 2. Introduction
+
+### 2.1 The UK Context
+
+From bustling city boroughs to quiet rural hamlets, the UK is home to a diverse tapestry of local communities. Each area faces unique challenges—ranging from timely bin collection schedules to promoting local volunteering opportunities or bridging digital divides. Despite plenty of tools and social networks, many local initiatives still struggle with siloed data, outdated systems, and a lack of trustworthy digital communication channels.
+
+### 2.2 Purpose and Vision
+
+Lcly aims to address this gap by providing an open-source platform that is:
+
+- **UX-first:** Ensuring people of all ages and technical backgrounds can participate easily.
+- **Trust-Focused:** Building confidence that user data is handled responsibly, and the platform isn't driven by hidden profit motives or intrusive surveillance.
+- **Infrastructure-Oriented:** Offering an extensible framework that local authorities, developers, and businesses can build upon—much like roads or public transport systems.
+
+By operating as public infrastructure, we envision a future where local communities can seamlessly coordinate events, share safety alerts, and drive grassroots civic engagement—without relying on scattered, commercial-driven solutions.
+
+## 3. Technical Rationale
+
+### 3.1 Why Open Source?
+
+Open source lies at the heart of Lcly's mission. Traditional proprietary solutions often struggle with transparency and vendor lock-in. By contrast, open source:
+
+- **Promotes Accountability:** Anyone can audit the code, ensuring security vulnerabilities or suspicious data practices do not go unnoticed.
+- **Fosters Collaboration:** Individuals, local councils, and private enterprises can all contribute code, local data, or feature improvements.
+- **Facilitates Adaptability:** Regions with unique needs—like Welsh-speaking communities or historically underrepresented groups—can adapt Lcly to fit their linguistic, cultural, or accessibility requirements.
+
+### 3.2 Why a UI/UX-First Approach?
+
+In the UK alone, residents span a wide demographic spectrum—from digital-savvy Gen Z to older adults less familiar with modern tech. By emphasizing simplicity and clarity in Lcly's design:
+
+- People can swiftly find local information (e.g., a map of GP surgeries, local fundraising events) without wading through clutter.
+- Trust is nurtured when users feel comfortable navigating an interface that doesn't overwhelm them or bury essential functions.
+- Adoption across the community becomes more achievable, reducing digital exclusion.
+- Allows development of solutions that go beyond digital interfaces to improve accessibility.
+
+## 4. Core Architecture Overview
+
+Lcly's architecture balances scalability and simplicity, using a modular stack that allows for continuous improvement and straightforward deployments.
+
+### 4.1 Frontend: React
+
+- **Framework:** Built on React for server-side rendering (SSR) and static site generation (SSG).
+- **UI Components:** Sourced from shadcn/ui, providing polished, customizable React components.
+- **Styling:** Tailwind CSS for rapid UI development and consistent design.
+- **Rationale:** React offers robust performance, SEO advantages, and flexible rendering modes—crucial for community-driven content.
+
+### 4.2 Data Layer: Supabase
+
+- **Database:** Postgres under the hood, managed by Supabase.
+- **Authentication:** Supabase Auth for user signup, login, and session handling.
+- **Real-time Features:** Supabase's real-time capabilities allow for instant updates to local newsfeeds or emergency alerts.
+- **Rationale:** Supabase merges the scalability of a Postgres database with developer-friendly features (Auth, real-time subscriptions), but most importantly is built with the same Open Source ethos making it easy to self-host the entire stack easily.
+
+### 4.3 Integration Layer
+
+- **Open Data & Government APIs:** Connect to resources from the Office for National Statistics (ONS), Ordnance Survey, or local councils to fetch boundary definitions, population data, or local service information.
+- **Third-Party Services:** Potential integrations (e.g., local police or NHS data feeds) that keep the platform current.
+- **Custom Add-Ons:** Businesses or independent developers can plug in new features—like specialized local event management or commerce modules—through open APIs.
+
+### 4.4 Deployment: Vercel
+
+- **Hosting & CI/CD:** Lcly uses Vercel for automated builds, previews, and global edge deployment.
+- **Self-Hosting Option:** For councils or organizations that prefer in-house control, the platform can be deployed on private cloud or on-premises servers using Docker or direct Next.js hosting.
+
+## 5. Data, Trust, and Privacy
+
+### 5.1 Data Protection and GDPR
+
+As a UK-focused platform, GDPR compliance is a critical design consideration. Lcly's architecture enforces clear data boundaries:
+
+- **Consent-Oriented:** Users have control over what data they share—like location details or personal information.
+- **Data Minimization:** Only necessary user details are stored, reducing the risk associated with data breaches.
+- **Role-Based Access Control:** Administrative features, like moderating community forums, remain compartmentalized from standard user data.
+
+### 5.2 Verified Partners and Services
+
+To enhance trust, official local organizations (e.g., councils, charities) can apply for verified status. Verified accounts display a badge and follow stricter identity checks, preventing impersonation and misinformation.
+
+### 5.3 Community Moderation
+
+All social platforms must grapple with moderation. Lcly provides:
+
+- **Tools for Local Moderators:** Community-appointed or council-nominated individuals can monitor content for spam or abuse, with all decisions being publicly reviewable. Tools for setting up transparent automated moderation to be used where possible.
+- **Community Notes:** A community notes style system similar to X for adding context/fact-checking misinformation to avoid bias.
+- **Illegal content:** Automated and user reported systems for removing any illegal content. Providing transparent reasoning, helpful explanations of the law, weighted repercussions, and a fair community dispute process.
+- **Transparent Guidelines:** Clear code-of-conduct policies help maintain respectful dialogue.
+
+## 6. Deployment & Growth Strategy
+
+### 6.1 Easy Setup for Developers
+
+- **Fork and Go:** Lcly's repository is entirely open source—developers can quickly clone, configure environment variables, and spin up the platform.
+- **Documentation & Community:** A friendly developer community and how-to guides lower the barrier for custom extensions and integrations.
+
+### 6.2 Partnerships with Local Councils & Businesses
+
+- **Government Integration:** By offering a standardized platform, councils and community groups can more efficiently publicize events, local announcements, and public consultations.
+- **Sponsorship Opportunities:** Local businesses can sponsor features or promote events, ensuring a symbiotic relationship that remains user-centric rather than ad-heavy.
+
+### 6.3 Sustainability as Public Infrastructure
+
+Building a non-commercial platform means exploring alternative funding models:
+
+- **Public Grants & Philanthropy:** Tapping into government-backed community funds or corporate social responsibility programs.
+- **Membership or Service Fees:** Optional subscription tiers for organizations needing advanced analytics, custom branding, or specialized integrations.
+
+## 7. Lcly Governance
+
+### 7.1 Open-Source Community
+
+A strong governance model ensures that Lcly remains transparent, inclusive, and aligned with public interest:
+
+- **Core Maintainers:** A small group (including the original Lcly team) who guide project direction, review critical merges, and maintain data integrity.
+- **Contributors:** Anyone can submit pull requests or propose enhancements—encouraging grassroots innovation.
+- **Community Steering Committee:** Representatives from local councils, user groups, and nonprofits to keep the platform's focus on serving real community needs.
+
+### 7.2 Decision-Making and Updates
+
+- **Roadmap Discussion:** Regular open calls or forum discussions to decide on upcoming features.
+- **Public Vote Features (Experimental):** As the platform grows, certain local-level changes (like new data sets or feature requests) could be put to a user vote, reinforcing Lcly's democratic ethos.
+
+## 8. Future Outlook
+
+### 8.1 Advanced Civic Participation
+
+Long-term, Lcly envisions deeper civic tools, from online petitioning to local budgeting. By bundling these services in a trusted platform, more residents can engage in shaping their communities' futures.
+
+### 8.2 Nationwide Interoperability
+
+Though starting in the UK, the concept of open, community-centric digital infrastructure can scale internationally. Lessons learned in the UK's diverse localities can inform expansions to other regions.
+
+### 8.3 Continuous Innovation
+
+Because Lcly is open-source, it benefits from community-driven improvements. With an ever-evolving codebase and active contributor network, the platform can adapt to emerging technologies like AI-driven local insights or more immersive, real-time dashboards.
+
+## 9. Conclusion
+
+Lcly stands as a bold, community-oriented alternative to fragmented local networks and commercial social platforms. By weaving together open-source transparency, a UX-first philosophy, and a commitment to public trust, Lcly offers a standardized yet flexible foundation for local digital infrastructure in the UK.
+
+We invite developers, policymakers, businesses, and everyday residents to join us. Whether you're collaborating on code, championing local data accessibility, or simply using Lcly to find out when your bins are collected—together, we can build a UK where every community is truly connected.
+
+## References & Additional Resources
+
+- Official Lcly Repository: [github.com/lcly/lcly-web](https://github.com/lcly/lcly-web)
+- Lcly Policies: [https://github.com/LclyMe/policies](https://github.com/LclyMe/policies)
+- Next.js Documentation: [nextjs.org/docs](https://nextjs.org/docs)
+- Supabase Docs: [supabase.com/docs](https://supabase.com/docs)
+- Tailwind CSS: [tailwindcss.com](https://tailwindcss.com)
+- shadcn/ui: [ui.shadcn.com](https://ui.shadcn.com)
+- ONS API (Example): [developer.ons.gov.uk](https://developer.ons.gov.uk)
+
+## Join the Lcly Movement
+
+- Website: [lcly.me](https://lcly.me)
+- Github: [github.com/lclyme](https://github.com/lclyme)
+- Twitter: [@lclyme](https://twitter.com/lclyme)
+- Discord: [https://discord.gg/BZXF9wx9Pw](https://discord.gg/BZXF9wx9Pw)
+
+Together, we'll shape the digital future of local communities—openly, securely, and for the public good.

--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useMounted() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  return mounted;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-label": "^2.1.1",
+        "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
@@ -1350,6 +1351,36 @@
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.2.tgz",
+      "integrity": "sha512-EFI1N/S3YxZEW/lJ/H1jY3njlvTd8tBmgKEn4GHi51+aMm94i6NmAJstsm5cu3yJwYqYc93gpCPm21FeAbFk6g==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-label": "^2.1.1",
+    "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",


### PR DESCRIPTION
Added two new pages for:
- Roadmap
- Whitepaper (ELI5 version

Whitepaper currently is stored in repo as MD, possibly something we want to move into a separate git or file too?

<img width="1726" alt="Screenshot 2025-01-29 at 02 21 47" src="https://github.com/user-attachments/assets/c43b1de3-530a-4bde-8ec3-6874f6f5752f" />
<img width="1726" alt="Screenshot 2025-01-29 at 02 21 15" src="https://github.com/user-attachments/assets/450eeeb8-fb08-4ad8-9fc6-5372e2fe35a3" />
